### PR TITLE
feat: add pending course management UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ workship/target/classes/com/ledong/entity/Charge.class
 workship/target/classes/com/ledong/entity/Coach.class
 .gitignore
 workship/target/classes/com/ledong/entity/PrepaidCard.class
+.DS_Store

--- a/docs/course-record-integration.md
+++ b/docs/course-record-integration.md
@@ -1,0 +1,85 @@
+# 教练录课与管理员录取：跨项目联调说明
+
+适用分支：三个仓库的 `course-record`。本文件是联调执行清单；需求以《教练小程序录课与管理员录取_最终需求共识文档_v2.1》为准，接口与实现细节以《教练小程序录课与管理员录取_详细设计文档_v1.0_文件库版》为准。
+
+## 1. 联调范围与职责
+
+- `ledong-db`：创建 `pending_course` 表，提供管理员待审列表与录取接口；录取时适配并调用既有 `CourseService.CreateCourse`。
+- `ledong-tennis/material-kit-react`：提供“教练填报课程”管理页，按校区分组展示待审课并逐条录取。
+- `court-book`：教练身份初始化、待审课程 CRUD、会员搜索、正式课程只读查询；云函数直接连接 MySQL，不调用 `ledong-db` 的新接口。
+
+主流程：教练小程序提交待审课 → `pending_course` → 管理端查询 → 管理员逐条录取 → 既有正式录课逻辑创建 `course`、`spend`、`course_member` 并扣减余额/次数 → 物理删除待审记录。
+
+兼容边界：旧 Excel 页面、旧 duplicate 接口、旧 `POST /api/prepaidCard/course/create` 及其调用方不改动；Excel 与待审课不在同一页面混合。
+
+## 2. 上线前配置
+
+1. 在测试库执行 `ledong-db/db-migrate/create_pending_course.sql`；上线前用 `SHOW CREATE TABLE` 核对 `course`、`coach`、`court`、`prepaid_card`、`spend` 的实际字段。
+2. `ledong-db` 运行环境设置 `TZ=Asia/Shanghai`；MySQL `DATETIME`、HTTP 时间字符串和 `updatedAt` 比较均使用业务时间 `YYYY-MM-DD HH:mm:ss`。
+3. 为四个新云函数 `coach_context`、`pending_course`、`member_search`、`coach_course_list` 配置相同的 `DB_HOST`、`DB_PORT`、`DB_USER`、`DB_PASSWORD`、`DB_DATABASE` 与同一个高强度 `COACH_CONTEXT_SECRET`。
+4. 确认微信云函数到 MySQL 的网络白名单、账号权限和 TLS/网络配置可用；云函数只允许写 `pending_course`，不写正式业务表。
+5. 管理端沿用现有 Axios `secure` 请求头；测试账号需具备既有管理后台权限。
+
+## 3. 接口与数据契约
+
+### 管理后台 API
+
+- `GET /api/pending-course`：复用 `secure` 鉴权；返回按 `startTime DESC, id DESC` 排序的扁平待审课程 DTO，前端按校区分组。
+- `POST /api/pending-course/{id}/admit`：复用 `secure` 鉴权，使用 JSON；请求包含 `updatedAt` 与完整 `course` 数据。成功返回 `{ "id": <formalCourseId> }`。
+
+录取请求中的 `course` 至少包含：`coachId`、`courtId`、`startTime`、`endTime`、`duration`、`courseType`、`isAdult`、`description` 和 `membersData`。每个会员消费项使用 `memberId`、`charge`、`times`、`annualTimes`、`description`、`quantities`。
+
+关键错误码：`PENDING_UPDATED`、`PENDING_NOT_FOUND`、`COURSE_DUPLICATE`、`INVALID_MEMBER_SPEND`、`DUPLICATE_MEMBER`、`COACH_NOT_FOUND`、`COURT_NOT_FOUND`、`MEMBER_NOT_FOUND`、`FORMAL_CREATED_PENDING_DELETE_FAILED`、`INTERNAL_ERROR`。管理端统一使用既有 notify 展示，`PENDING_UPDATED` 与 `PENDING_NOT_FOUND` 后刷新列表。
+
+### 小程序云函数
+
+- `coach_context`：初始化教练上下文、校区和 OpenID 绑定 token。
+- `pending_course`：`create`、`list`、`update`、`delete`；只读/写 `pending_course`。
+- `member_search`：姓名模糊搜索，最多 20 条，返回余额字段。
+- `coach_course_list`：只读当前教练当前自然月及前两个月的正式课；范围固定按 `Asia/Shanghai`，每页 30 条。
+
+云函数业务时间也使用 `YYYY-MM-DD HH:mm:ss`。`course_type` 为 `-2/-1/0/1/2`；订场 `is_adult` 继续沿用正式课程的实际字段值与默认语义。
+
+## 4. 部署顺序
+
+1. 执行数据库迁移并检查表、索引和权限。
+2. 部署 `ledong-db`，确认新路由可用且旧 Excel 录课接口仍可用。
+3. 分别安装并部署四个云函数依赖，写入配置并在微信环境验证 token、MySQL 连接和日志。
+4. 发布 `court-book` 小程序版本。
+5. 发布 `ledong-tennis/material-kit-react` 管理端版本。
+
+回滚时可回滚后台、管理端或小程序应用版本；保留 `pending_course` 表及未消费记录，不删除待审数据。
+
+## 5. 联调验收清单
+
+### 核心闭环
+
+1. 教练使用小程序新增班课（多人、不同扣费类型）后，在待审列表看到该课程。
+2. 管理端“教练填报课程”页面显示课程，按校区分组；展开会员明细、欠费确认、手动刷新均正常。
+3. 管理员录取后，确认正式课程可见，`spend` 与 `course_member` 已写入，余额/次数按既有逻辑扣减，待审记录被物理删除。
+4. 管理端立即刷新后不再显示已录取课程；小程序待审页刷新后也不再显示该课程。
+
+### 异常与边界
+
+1. 管理员加载待审课后，教练修改该课程；录取应返回 `PENDING_UPDATED`，不创建正式课。
+2. 教练编辑页中的待审课已被录取/删除；保存或删除应返回 `PENDING_NOT_FOUND`，小程序提示后退出或移除本地卡片。
+3. 检查体验课、订场、班课、私教；特别验证订场 `isAdult` 与既有正式录课保持一致。
+4. 验证课时费为 0、次卡/年卡最小 0.5、重复会员拒绝、无效会员/校区/教练的错误提示。
+5. 在北京时间月初、跨年和二月检查正式课“三自然月”范围；云函数运行时区变化不应改变结果。
+
+### 旧功能回归
+
+1. 使用旧 Excel 自动录课完成一次创建，确认旧页面、FormData、duplicate 与既有正式课程创建接口保持可用。
+2. 检查管理端首页、会员、统计、自动录课菜单与鉴权正常。
+3. 检查小程序既有登录、会员中心、订场和旧云函数不受影响。
+
+## 6. 已确认业务边界
+
+- 当前按单管理员操作假设联调，不额外处理同一待审课的管理员并发录取。
+- 微信小程序使用既有严格认证体系；本期不额外扩展电话/token 防护方案。
+- 本期不处理小程序重复并发提交冲突。
+- 不增加消息通知、批量填报、批量录取、动态 TabBar 或旧 Excel 页面重构。
+
+## 7. 联调记录
+
+每次联调请记录：环境、三仓库 `course-record` 提交 SHA、迁移版本、云函数版本与配置校验结果、测试账号、步骤、实际结果、SQL/应用日志位置和阻塞项。不要在用户提示、前端日志或本文件中写入数据库密码、token 或手机号等敏感信息。

--- a/material-kit-react/src/components/searchComponent/pendingCourse.tsx
+++ b/material-kit-react/src/components/searchComponent/pendingCourse.tsx
@@ -1,0 +1,152 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Paper, Stack, Typography } from '@mui/material'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import { useSnackbar } from 'notistack'
+import Axios from '../../common/axios/axios'
+import PendingCourseCard from './pendingCourseCard'
+import { PendingCourse } from './pendingCourseTypes'
+import { BalanceWarnings, calculateBalanceWarnings } from './pendingCourseBalance'
+import { toAdmitRequest } from './pendingCourseTypes'
+
+type LoadReason = 'initial' | 'manual' | 'auto' | 'afterAdmit'
+
+const errorMessage = (error: any) => error?.response?.data?.message || error?.message || '请求失败，请稍后重试'
+
+const PendingCoursePage = () => {
+  const { enqueueSnackbar } = useSnackbar()
+  const [courses, setCourses] = useState<PendingCourse[]>([])
+  const [loading, setLoading] = useState(false)
+  const [initialLoaded, setInitialLoaded] = useState(false)
+  const [initialLoadFailed, setInitialLoadFailed] = useState(false)
+  const [collapsedById, setCollapsedById] = useState<Record<number, boolean>>({})
+  const [admittingById, setAdmittingById] = useState<Record<number, boolean>>({})
+  const [dialogCourse, setDialogCourse] = useState<PendingCourse | null>(null)
+  const [dialogWarnings, setDialogWarnings] = useState<BalanceWarnings>({ currentDebt: [], afterDebt: [] })
+  const requestSeqRef = useRef(0)
+  const refreshInFlightRef = useRef(false)
+  const coursesRef = useRef<PendingCourse[]>([])
+  const interactionRef = useRef(false)
+
+  useEffect(() => {
+    coursesRef.current = courses
+  }, [courses])
+
+  useEffect(() => {
+    interactionRef.current = Boolean(dialogCourse) || Object.keys(admittingById).length > 0
+  }, [dialogCourse, admittingById])
+
+  const loadCourses = useCallback(async (reason: LoadReason) => {
+    if (refreshInFlightRef.current) return
+    refreshInFlightRef.current = true
+    const requestSeq = ++requestSeqRef.current
+    if (reason !== 'auto') setLoading(true)
+    try {
+      const response = await Axios.get('/api/pending-course')
+      const nextCourses: PendingCourse[] = Array.isArray(response.data) ? response.data : (response.data?.data || [])
+      if (requestSeq !== requestSeqRef.current) return
+      setCourses(nextCourses)
+      setCollapsedById((previous) => nextCourses.reduce((next, course) => {
+        next[course.id] = Boolean(previous[course.id])
+        return next
+      }, {} as Record<number, boolean>))
+      setInitialLoaded(true)
+      setInitialLoadFailed(false)
+    } catch (error) {
+      if (requestSeq === requestSeqRef.current) {
+        setInitialLoaded(true)
+        if (coursesRef.current.length === 0) setInitialLoadFailed(true)
+        enqueueSnackbar(errorMessage(error), { variant: 'error' })
+      }
+    } finally {
+      refreshInFlightRef.current = false
+      if (reason !== 'auto' && requestSeq === requestSeqRef.current) setLoading(false)
+    }
+  }, [enqueueSnackbar])
+
+  useEffect(() => {
+    loadCourses('initial')
+    const interval = window.setInterval(() => {
+      if (!interactionRef.current && !refreshInFlightRef.current) loadCourses('auto')
+    }, 60 * 1000)
+    return () => {
+      window.clearInterval(interval)
+      requestSeqRef.current += 1
+    }
+  }, [loadCourses])
+
+  const groups = useMemo(() => {
+    const byCourt = courses.reduce((result, course) => {
+      const key = String(course.courtId)
+      if (!result[key]) result[key] = []
+      result[key].push(course)
+      return result
+    }, {} as Record<string, PendingCourse[]>)
+    return Object.values(byCourt).sort((left, right) => {
+      const leftName = left[0]?.courtName || '\uffff'
+      const rightName = right[0]?.courtName || '\uffff'
+      return leftName.localeCompare(rightName, 'zh-CN')
+    }).map((group) => group.sort((left, right) => right.startTime.localeCompare(left.startTime) || right.id - left.id))
+  }, [courses])
+
+  const admit = useCallback(async (course: PendingCourse) => {
+    if (admittingById[course.id]) return
+    setAdmittingById((previous) => ({ ...previous, [course.id]: true }))
+    try {
+      await Axios.post(`/api/pending-course/${course.id}/admit`, toAdmitRequest(course))
+      enqueueSnackbar('课程已录取', { variant: 'success' })
+      setCourses((previous) => previous.filter((item) => item.id !== course.id))
+      await loadCourses('afterAdmit')
+    } catch (error: any) {
+      enqueueSnackbar(errorMessage(error), { variant: 'error' })
+      const errorCode = error?.response?.data?.errorCode
+      if (errorCode === 'PENDING_UPDATED' || errorCode === 'PENDING_NOT_FOUND') loadCourses('afterAdmit')
+    } finally {
+      setAdmittingById((previous) => {
+        const next = { ...previous }
+        delete next[course.id]
+        return next
+      })
+    }
+  }, [admittingById, enqueueSnackbar, loadCourses])
+
+  const requestAdmit = (course: PendingCourse) => {
+    const warnings = calculateBalanceWarnings(course.membersData)
+    if (warnings.currentDebt.length || warnings.afterDebt.length) {
+      setDialogWarnings(warnings)
+      setDialogCourse(course)
+      return
+    }
+    admit(course)
+  }
+
+  const warningLines = [...dialogWarnings.currentDebt.map((warning) => `${warning.member.memberName || warning.member.memberId} 当前已欠费（等效余额 ${warning.currentBalance}）`),
+    ...dialogWarnings.afterDebt.map((warning) => `${warning.member.memberName || warning.member.memberId} 扣费后将欠费（等效余额 ${warning.afterBalance}）`)]
+
+  return <Box sx={{ width: '100%', height: '100%', overflow: 'auto', pr: 2 }}>
+    <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+      <Typography variant="h5">教练填报课程</Typography>
+      <Button variant="outlined" startIcon={<RefreshIcon />} onClick={() => loadCourses('manual')} disabled={loading || Object.keys(admittingById).length > 0}>刷新</Button>
+    </Stack>
+    {initialLoadFailed && courses.length === 0 && <Alert severity="error" action={<Button color="inherit" size="small" onClick={() => loadCourses('manual')}>重新加载</Button>} sx={{ mb: 2 }}>待审课程加载失败，请重试。</Alert>}
+    {initialLoaded && !initialLoadFailed && groups.length === 0 && <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}><Typography color="text.secondary">暂无待审课程</Typography></Paper>}
+    {groups.map((group) => <Paper key={group[0].courtId} variant="outlined" sx={{ p: 2, mb: 2 }}>
+      <Typography variant="h6">{group[0].courtName || `校区已失效（${group[0].courtId}）`}</Typography>
+      <Divider sx={{ my: 1.5 }} />
+      {group.map((course) => <PendingCourseCard key={course.id} course={course} collapsed={Boolean(collapsedById[course.id])} admitting={Boolean(admittingById[course.id])}
+        onToggle={() => setCollapsedById((previous) => ({ ...previous, [course.id]: !previous[course.id] }))} onAdmit={() => requestAdmit(course)} />)}
+    </Paper>)}
+    <Dialog open={Boolean(dialogCourse)} onClose={() => setDialogCourse(null)}>
+      <DialogTitle>欠费提醒</DialogTitle>
+      <DialogContent>
+        <Typography>以下会员已欠费或本次扣费后将欠费。确认后仍将继续录取课程：</Typography>
+        <Stack sx={{ mt: 1 }} spacing={0.5}>{warningLines.map((line, index) => <Typography key={index} variant="body2">• {line}</Typography>)}</Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setDialogCourse(null)}>取消</Button>
+        <Button variant="contained" onClick={() => { const course = dialogCourse; setDialogCourse(null); if (course) admit(course) }}>继续录取</Button>
+      </DialogActions>
+    </Dialog>
+  </Box>
+}
+
+export default PendingCoursePage

--- a/material-kit-react/src/components/searchComponent/pendingCourseBalance.ts
+++ b/material-kit-react/src/components/searchComponent/pendingCourseBalance.ts
@@ -1,0 +1,43 @@
+import { MemberSpend } from './pendingCourseTypes'
+
+const TIMES_CARD_UNIT_PRICE = 200
+const ANNUAL_CARD_UNIT_PRICE = 150
+
+const numberValue = (value: unknown) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export type BalanceWarning = {
+  member: MemberSpend
+  currentBalance: number
+  deduction?: number
+  afterBalance?: number
+}
+
+export type BalanceWarnings = {
+  currentDebt: BalanceWarning[]
+  afterDebt: BalanceWarning[]
+}
+
+export const calculateBalanceWarnings = (members: MemberSpend[] = []): BalanceWarnings => {
+  const currentDebt: BalanceWarning[] = []
+  const afterDebt: BalanceWarning[] = []
+
+  members.forEach((member) => {
+    const currentBalance = numberValue(member.restCharge)
+      + numberValue(member.timesCount) * TIMES_CARD_UNIT_PRICE
+      + numberValue(member.annualCount) * ANNUAL_CARD_UNIT_PRICE
+    const deduction = numberValue(member.charge)
+      + numberValue(member.times) * TIMES_CARD_UNIT_PRICE
+      + numberValue(member.annualTimes) * ANNUAL_CARD_UNIT_PRICE
+    const afterBalance = currentBalance - deduction
+
+    if (currentBalance < 0) currentDebt.push({ member, currentBalance })
+    if (currentBalance >= 0 && afterBalance < 0) {
+      afterDebt.push({ member, currentBalance, deduction, afterBalance })
+    }
+  })
+
+  return { currentDebt, afterDebt }
+}

--- a/material-kit-react/src/components/searchComponent/pendingCourseCard.tsx
+++ b/material-kit-react/src/components/searchComponent/pendingCourseCard.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Button, Card, CardActions, CardContent, Chip, Collapse, Divider, IconButton, Stack, Typography } from '@mui/material'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import { PendingCourse, courseTypeLabel, deductionLabel } from './pendingCourseTypes'
+
+type Props = {
+  course: PendingCourse
+  collapsed: boolean
+  admitting: boolean
+  onToggle: () => void
+  onAdmit: () => void
+}
+
+const PendingCourseCard = ({ course, collapsed, admitting, onToggle, onAdmit }: Props) => {
+  const isBooking = course.courseType === 0
+  const courtName = course.courtName || `校区已失效（${course.courtId}）`
+
+  return <Card variant="outlined" sx={{ mb: 1.5 }}>
+    <CardContent sx={{ pb: 1 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
+        <Stack spacing={0.5}>
+          <Typography variant="h6">{course.coachName || `教练已失效（${course.coachId}）`}</Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            <Chip size="small" label={courseTypeLabel(course.courseType)} />
+            {!isBooking && <Chip size="small" variant="outlined" label={course.isAdult === 0 ? '儿童' : '成人'} />}
+            <Chip size="small" variant="outlined" label={courtName} />
+          </Stack>
+        </Stack>
+        <IconButton aria-label={collapsed ? '展开会员明细' : '收起会员明细'} onClick={onToggle} size="small">
+          {collapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+        </IconButton>
+      </Stack>
+      <Typography variant="body2" sx={{ mt: 1.5 }}>
+        {course.startTime} 至 {course.endTime}（{course.duration} 小时）
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        备注：{course.description || '无'}
+      </Typography>
+      <Collapse in={!collapsed} timeout="auto" unmountOnExit>
+        <Divider sx={{ my: 1.5 }} />
+        {course.membersData && course.membersData.length > 0 ? course.membersData.map((member) => (
+          <Stack key={member.memberId} direction="row" justifyContent="space-between" spacing={2} sx={{ py: 0.5 }}>
+            <Typography variant="body2">{member.memberName || `会员已失效（${member.memberId}）`}{member.memberNumber ? `（${member.memberNumber}）` : ''}</Typography>
+            <Typography variant="body2" color="text.secondary" align="right">
+              {deductionLabel(member)}；等效价格 {member.description}；人数 {member.quantities}
+            </Typography>
+          </Stack>
+        )) : <Typography variant="body2" color="text.secondary">本课程没有会员消费明细。</Typography>}
+      </Collapse>
+    </CardContent>
+    <CardActions sx={{ justifyContent: 'flex-end', px: 2, pb: 1.5 }}>
+      <Button variant="contained" size="small" startIcon={<CheckCircleOutlineIcon />} disabled={admitting} onClick={onAdmit}>
+        {admitting ? '录取中…' : '录取'}
+      </Button>
+    </CardActions>
+  </Card>
+}
+
+export default PendingCourseCard

--- a/material-kit-react/src/components/searchComponent/pendingCourseTypes.ts
+++ b/material-kit-react/src/components/searchComponent/pendingCourseTypes.ts
@@ -1,0 +1,83 @@
+export type MemberSpend = {
+  memberId: number
+  memberName?: string
+  memberNumber?: string
+  charge: number
+  times: number
+  annualTimes: number
+  description: number
+  quantities: number
+  restCharge?: number
+  timesCount?: number
+  annualCount?: number
+}
+
+export type PendingCourse = {
+  id: number
+  coachId: number
+  coachName?: string
+  courtId: number
+  courtName?: string
+  startTime: string
+  endTime: string
+  duration: number
+  courseType: number
+  isAdult: number
+  description: string
+  membersData: MemberSpend[]
+  createdAt: string
+  updatedAt: string
+}
+
+export type AdmitRequest = {
+  updatedAt: string
+  course: {
+    coachId: number
+    courtId: number
+    startTime: string
+    endTime: string
+    duration: number
+    courseType: number
+    isAdult: number
+    description: string
+    membersData: Array<Pick<MemberSpend, 'memberId' | 'charge' | 'times' | 'annualTimes' | 'description' | 'quantities'>>
+  }
+}
+
+export const COURSE_TYPE_LABELS: Record<number, string> = {
+  [-2]: '体验课未成单',
+  [-1]: '体验课成单',
+  0: '订场',
+  1: '班课',
+  2: '私教',
+}
+
+export const courseTypeLabel = (courseType: number) => COURSE_TYPE_LABELS[courseType] || `未知类型（${courseType}）`
+
+export const deductionLabel = (member: MemberSpend) => {
+  if (Number(member.times) > 0) return `次卡 ${member.times}`
+  if (Number(member.annualTimes) > 0) return `年卡 ${member.annualTimes}`
+  return `课时费 ${member.charge}`
+}
+
+export const toAdmitRequest = (course: PendingCourse): AdmitRequest => ({
+  updatedAt: course.updatedAt,
+  course: {
+    coachId: course.coachId,
+    courtId: course.courtId,
+    startTime: course.startTime,
+    endTime: course.endTime,
+    duration: course.duration,
+    courseType: course.courseType,
+    isAdult: course.isAdult,
+    description: course.description || '',
+    membersData: (course.membersData || []).map((member) => ({
+      memberId: member.memberId,
+      charge: Number(member.charge) || 0,
+      times: Number(member.times) || 0,
+      annualTimes: Number(member.annualTimes) || 0,
+      description: Number(member.description) || 0,
+      quantities: Number(member.quantities) || 0,
+    })),
+  },
+})

--- a/material-kit-react/src/components/sidebar/sideMenu.tsx
+++ b/material-kit-react/src/components/sidebar/sideMenu.tsx
@@ -16,7 +16,7 @@
  * @LastEditTime: 2022-04-11 11:10:25
  * @content: edit your page content
  */
-import { Avatar, Box, Stack, Typography, Paper, IconButton } from '@mui/material';
+import { Avatar, Box, Stack, Typography, Paper, IconButton, ButtonBase } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import Tooltip, { tooltipClasses, TooltipProps } from '@mui/material/Tooltip';
 import React, { useEffect } from 'react';
@@ -30,6 +30,7 @@ import { logOut } from '../../store/actions/usersActions';
 import FolderIcon from '@mui/icons-material/Folder';
 import AnalyticsSharp from '@mui/icons-material/AnalyticsSharp';
 import AccessAlarmsOutlined from '@mui/icons-material/AccessAlarmsOutlined';
+import AssignmentTurnedInOutlined from '@mui/icons-material/AssignmentTurnedInOutlined';
 import { clearDatasetFilesCache } from "../../store/actions/filesAndFoldersActions"
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import GridViewIcon from '@mui/icons-material/GridView';
@@ -190,6 +191,23 @@ function SideMenu(props) {
                             // navigate(`/explore`)
                         }}>
                          自动录课
+                        </Typography>
+                    </Stack>
+                    <Stack
+                        component={ButtonBase}
+                        direction="column"
+                        justifyContent="flex-start"
+                        alignItems="center"
+                        spacing={1}
+                        onClick={async () => {
+                            indexChange(4)
+                        }}
+                        aria-label="教练填报课程"
+                        sx={{ width: '100%', height: 80, color: '#8b8b8b', cursor: 'pointer', '&:hover': { background: 'rgba(0, 0, 0, 0.04)', color: '#a1a1a1' } }}
+                    >
+                        <AssignmentTurnedInOutlined fontSize="large" />
+                        <Typography variant="button" display="block" gutterBottom sx={{}}>
+                         教练填报课程
                         </Typography>
                     </Stack>
                 </Stack>

--- a/material-kit-react/src/components/whIndex/indexContainer.tsx
+++ b/material-kit-react/src/components/whIndex/indexContainer.tsx
@@ -14,6 +14,7 @@ import { Button, Card, Box,CardHeader, Checkbox, Divider, Grid, List, ListItem, 
 import SearchTask from '../searchComponent/searchTask'
 import Analyse from '../searchComponent/analyse'
 import Autoloading from '../searchComponent/autoloading'
+import PendingCourse from '../searchComponent/pendingCourse'
 function IndexContainer(props) {
     const index = props.index
   
@@ -25,7 +26,7 @@ function IndexContainer(props) {
   
     return (
       <Box   justifyContent="space-around" alignItems="center" sx={{width:'96vw',height:'97%',padding:'20px 0 0 10px'}}>
-     {index===0?<AdminComp />:index===1?<SearchTask />:index===2?<Analyse />:<Autoloading />}
+     {index===0?<AdminComp />:index===1?<SearchTask />:index===2?<Analyse />:index===3?<Autoloading />:index===4?<PendingCourse />:null}
       </Box>
     );
   }


### PR DESCRIPTION
## 背景

为管理后台增加教练待审课程的查看和录取能力，与小程序录课流程完成联调。

## 主要改动

- 新增待审课程列表、课程卡片、余额计算及类型定义。
- 在现有业务入口中增加待审课程管理菜单。
- 支持手动刷新、录取确认、余额不足提示和冲突后的列表刷新。
- 接口继续使用现有 Axios `secure` 请求头。
- 补充三端联调及发布说明。

## Scope 边界

- 未修改旧 Autoloading/Excel 录课页面及解析流程。
- 未修改 Redux store、旧菜单索引语义或生产 webpack 配置。
- 未增加批量录取、并发管理员协调或旧页面重构。

## 验证

- `npm run build:prod` 通过。
- 仅保留项目已有的 bundle/图片体积警告。
- 新增代码为静态前端资源，不包含 macOS 原生构建产物；Linux x86 部署无架构绑定问题。
- `git diff --check`

## 发布注意

需在后端迁移和新接口发布完成后再发布管理端。